### PR TITLE
[improve][broker] Unblock stuck Key_Shared subscription after consumer reconnect

### DIFF
--- a/conf/broker.conf
+++ b/conf/broker.conf
@@ -336,6 +336,14 @@ maxUnackedMessagesPerSubscriptionOnBrokerBlocked=0.16
 # Broker periodically checks if subscription is stuck and unblock if flag is enabled. (Default is disabled)
 unblockStuckSubscriptionEnabled=false
 
+# If enabled subscriptions stores keys of messages which allows consumer not
+# to stuck in case it goes to recently assigned. The setting allows to overcome
+# situation when new KeyShared consumers will not get any messages until a consumer
+# that did get messages disconnects or acks/nacks some messages
+# The trade of is the need to track all the not acked messages in subscription
+# which could potentially lead to performance degradation and higher memory consumption
+rememberNotAckedMessagesKey=false
+
 # Tick time to schedule task that checks topic publish rate limiting across all topics
 # Reducing to lower value can give more accuracy while throttling publish but
 # it uses more CPU to perform frequent check. (Disable publish throttling with value 0)

--- a/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
+++ b/pulsar-broker-common/src/main/java/org/apache/pulsar/broker/ServiceConfiguration.java
@@ -891,6 +891,16 @@ public class ServiceConfiguration implements PulsarConfiguration {
     private double maxUnackedMessagesPerSubscriptionOnBrokerBlocked = 0.16;
     @FieldContext(
             category = CATEGORY_POLICIES,
+            doc = "If enabled subscriptions stores keys of messages which allows consumer not "
+                    + "to stuck in case it goes to recently assigned. The setting allows to overcome "
+                    + "situation when new KeyShared consumers will not get any messages until a consumer "
+                    + "that did get messages disconnects or acks/nacks some messages "
+                    + "The trade of is the need to track all the not acked messages in subscription"
+                    + "which could potentially lead to performance degradation and higher memory consumption"
+    )
+    private boolean rememberNotAckedMessagesKey = false;
+    @FieldContext(
+            category = CATEGORY_POLICIES,
             doc = "Maximum size of Consumer metadata")
     private int maxConsumerMetadataSize = 1024;
     @FieldContext(

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Subscription.java
@@ -104,6 +104,26 @@ public interface Subscription extends MessageExpirer {
 
     boolean isSubscriptionMigrated();
 
+    default boolean isPendingAckMessageKeysRemembered() {
+        return false;
+    }
+
+    default void addPendingMessageKey(Entry pendingEntry, String subscription, long consumerId) {
+        //Default is no op
+    }
+
+    default void removePendingMessageKey(long pendingEntryId) {
+        //Default is no op
+    }
+
+    default void cleanPendingMessageKeys() {
+        //Default is no op
+    }
+
+    default boolean couldSendToConsumer(String messageKey, long consumerId) {
+        return true;
+    }
+
     default void processReplicatedSubscriptionSnapshot(ReplicatedSubscriptionsSnapshot snapshot) {
         // Default is no-op
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentDispatcherMultipleConsumers.java
@@ -200,6 +200,9 @@ public class PersistentDispatcherMultipleConsumers extends AbstractDispatcherMul
     public synchronized void removeConsumer(Consumer consumer) throws BrokerServiceException {
         // decrement unack-message count for removed consumer
         addUnAckedMessages(-consumer.getUnackedMessages());
+        if (subscription.isPendingAckMessageKeysRemembered()) {
+            consumer.getPendingAcks().keys().forEach(value -> subscription.removePendingMessageKey(value.second));
+        }
         if (consumerSet.removeAll(consumer) == 1) {
             consumerList.remove(consumer);
             log.info("Removed consumer {} with pending {} acks", consumer, consumer.getPendingAcks().size());

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -95,11 +95,15 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     @DataProvider(name = "data")
     public Object[][] dataProvider() {
         return new Object[][] {
-                // Topic-Type and "Batching"
-                { "persistent", false  },
-                { "persistent", true  },
-                { "non-persistent", false },
-                { "non-persistent", true },
+                // Topic-Type, "Batching", "rememberUnackedMessages"
+                { "persistent", false, false  },
+                { "persistent", true, false  },
+                { "non-persistent", false, false },
+                { "non-persistent", true, false },
+                { "persistent", false, true  },
+                { "persistent", true, true  },
+                { "non-persistent", false, true },
+                { "non-persistent", true, true },
         };
     }
 
@@ -128,6 +132,7 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
     @AfterMethod(alwaysRun = true)
     public void resetDefaultNamespace() throws Exception {
+        this.conf.setRememberNotAckedMessagesKey(false); //reset to default
         List<String> list = admin.namespaces().getTopics("public/default");
         for (String topicName : list){
             if (!pulsar.getBrokerService().isSystemTopic(topicName)) {
@@ -140,8 +145,16 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     private static final int NUMBER_OF_KEYS = 300;
 
     @Test(dataProvider = "data")
-    public void testSendAndReceiveWithHashRangeAutoSplitStickyKeyConsumerSelector(String topicType, boolean enableBatch)
+    public void testSendAndReceiveWithHashRangeAutoSplitStickyKeyConsumerSelector(
+            String topicType,
+            boolean enableBatch,
+            boolean rememberUnackedKeys
+    )
             throws PulsarClientException {
+        if (rememberUnackedKeys) {
+            this.conf.setRememberNotAckedMessagesKey(true);
+        }
+
         String topic = topicType + "://public/default/key_shared-" + UUID.randomUUID();
 
         @Cleanup
@@ -167,7 +180,15 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     }
 
     @Test(dataProvider = "data")
-    public void testSendAndReceiveWithBatching(String topicType, boolean enableBatch) throws Exception {
+    public void testSendAndReceiveWithBatching(
+            String topicType,
+            boolean enableBatch,
+            boolean rememberUnackedKeys
+    ) throws Exception {
+        if (rememberUnackedKeys) {
+            this.conf.setRememberNotAckedMessagesKey(true);
+        }
+
         String topic = topicType + "://public/default/key_shared-" + UUID.randomUUID();
 
         @Cleanup
@@ -264,8 +285,13 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     @Test(dataProvider = "data")
     public void testConsumerCrashSendAndReceiveWithHashRangeAutoSplitStickyKeyConsumerSelector(
         String topicType,
-        boolean enableBatch
+        boolean enableBatch,
+        boolean rememberUnackedKeys
     ) throws PulsarClientException, InterruptedException {
+        if (rememberUnackedKeys) {
+            this.conf.setRememberNotAckedMessagesKey(true);
+        }
+
         String topic = topicType + "://public/default/key_shared_consumer_crash-" + UUID.randomUUID();
 
         @Cleanup
@@ -308,8 +334,13 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
     @Test(dataProvider = "data")
     public void testNonKeySendAndReceiveWithHashRangeAutoSplitStickyKeyConsumerSelector(
         String topicType,
-        boolean enableBatch
+        boolean enableBatch,
+        boolean rememberUnackedKeys
     ) throws PulsarClientException {
+        if (rememberUnackedKeys) {
+            this.conf.setRememberNotAckedMessagesKey(true);
+        }
+
         String topic = topicType + "://public/default/key_shared_none_key-" + UUID.randomUUID();
 
         @Cleanup
@@ -1629,5 +1660,112 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
 
         log.info("Got {} other messages...", sum);
         Assert.assertEquals(sum, delayedMessages + messages);
+    }
+
+    @Test
+    public void testSharedKeysOrderingWhenAddingConsumers() throws Exception {
+        this.conf.setRememberNotAckedMessagesKey(true);
+
+        String topic = "testSharedKeysOrderingWhenAddingConsumers-" + UUID.randomUUID();
+
+        @Cleanup
+        Producer<Integer> producer = createProducer(topic, false);
+
+        @Cleanup
+        Consumer<Integer> c1 = createConsumer(topic);
+
+        for (int i = 0; i < 10; i++) {
+            producer.newMessage()
+                    .key(String.valueOf(i))
+                    .value(i)
+                    .send();
+        }
+
+        // All the already published messages will be pre-fetched by C1.
+
+        // Adding a new consumer.
+        @Cleanup
+        Consumer<Integer> c2 = createConsumer(topic);
+
+        // Produce messages with the same keys as was pre-fetched by C1
+        for (int i = 10; i < 20; i++) {
+            producer.newMessage()
+                    .key(String.valueOf(i - 10))
+                    .value(i)
+                    .send();
+        }
+
+        // Closing c1, would trigger all messages to go to c2
+        c1.close();
+
+        for (int i = 0; i < 20; i++) {
+            Message<Integer> msg = c2.receive();
+            assertEquals(msg.getValue().intValue(), i);
+
+            c2.acknowledge(msg);
+        }
+    }
+
+    @Test
+    public void testConsumerIsNotBlockedForNewKeys() throws Exception {
+        this.conf.setRememberNotAckedMessagesKey(true);
+
+        String topic = "testConsumerIsNotBlockedForNewKeys-" + UUID.randomUUID();
+        String firstConsumerMessagesKey = "1";
+        String secondConsumerMessagesKey = "2";
+
+        @Cleanup
+        Producer<Integer> producer = createProducer(topic, false);
+
+        @Cleanup
+        Consumer<Integer> c1 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(0, 45000)));
+
+        for (int i = 0; i < 10; i++) {
+            producer.newMessage()
+                    .key(firstConsumerMessagesKey)
+                    .value(i)
+                    .send();
+        }
+
+        // Receive first message to make the key unacked
+        Message<Integer> firstMessage = c1.receive();
+        assertEquals(0, firstMessage.getValue().intValue());
+
+        // Adding a new consumer. It will become recently joined one
+        @Cleanup
+        Consumer<Integer> c2 = createConsumer(topic, KeySharedPolicy.stickyHashRange()
+                .ranges(Range.of(45001, 65535)));
+
+        //Produce messages with the key which was not pre-fetched by C1
+        for (int i = 10; i < 20; i++) {
+            producer.newMessage()
+                    .key(secondConsumerMessagesKey)
+                    .value(i)
+                    .send();
+        }
+
+        //C2 is not blocked as the key "newMessagesKey" was not pre-fetched by C1,
+        //and we are safe here not to break the key ordering
+        for (int i = 10; i < 20; i++) {
+            Message<Integer> msg = c2.receive();
+            assertEquals(i, msg.getValue().intValue());
+
+            c2.acknowledge(msg);
+        }
+
+        assertNull(c2.receive(1, TimeUnit.SECONDS));
+
+        c1.acknowledge(firstMessage);
+
+        //verify C1 receives all the messages in the correct order
+        for (int i = 1; i < 10; i++) {
+            Message<Integer> msg = c1.receive();
+            assertEquals(i, msg.getValue().intValue());
+
+            c1.acknowledge(msg);
+        }
+
+        assertNull(c1.receive(1, TimeUnit.SECONDS));
     }
 }


### PR DESCRIPTION
Fixes [#21199](https://github.com/apache/pulsar/issues/21199) and [#15705](https://github.com/apache/pulsar/issues/15705)


### Motivation

Current delivery mechanism blocks recently joined consumers from getting messages until all the previously delivered but not acknowledged messages are either acknowledged by the consumer which received the messages or the consumer disconnected

This is implementation trade off which allows not to track all the sent messages. This approach allows to reduce memory consumption and increase performance

The same time such implementation leads to a situation when a single failed message could lead to all the consumers blockage (described at https://github.com/apache/pulsar/issues/21199)

There is a setting allowOutOfOrderDelivery which allows to mitigate the described issue but leads to ordering guarantees loss

For some scenarios both consumption stuck and out of order delivery is not an option. The same time it could be ok to have more memory consumption and some minor performance degradation

### Modifications


1. Sent but not acknowledged messages tracking added
2. Messages tracking setting added

Tracking of delivered but not acknowledged messages allows not to send them to recently joined consumers and the same time preserve ordering

Making the new functionality switchable allows to preserve the current optimized memory consumption and performance for all the users with default settings. The same time users who is ready to memory and performance trade off getting opportunity to solve both consumers stuck problem and out of order delivery

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:

   - *Existing KeySharedSubscriptionTest extended with scenarios with new setting enabled*
   - *Added integration test for verification of preserving ordering with the new setting enabled*
   - *Added integration test for verification that recently joined consumers are not blocked when there are some unacknowledged messages delivered to existing consumers*

### Does this pull request potentially affect one of the following parts:

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

- [ ] `doc`
- [x] `doc-required`
- [ ] `doc-not-needed`
- [ ] `doc-complete`
