### PR TITLE
[fix][broker] Key_Shared subscription doesn't always deliver messages from the replay queue after a consumer disconnects and leaves a backlog

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerHashAssignmentsSnapshot.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ConsumerHashAssignmentsSnapshot.java
@@ -72,7 +72,7 @@ public class ConsumerHashAssignmentsSnapshot {
     }
 
     public ImpactedConsumersResult resolveImpactedConsumers(ConsumerHashAssignmentsSnapshot assignmentsAfter) {
-        return resolveConsumerRemovedHashRanges(this.hashRangeAssignments, assignmentsAfter.hashRangeAssignments);
+        return resolveConsumerUpdatedHashRanges(this.hashRangeAssignments, assignmentsAfter.hashRangeAssignments);
     }
 
     /**
@@ -111,28 +111,36 @@ public class ConsumerHashAssignmentsSnapshot {
      * @param mappingAfter the range mapping after the change
      * @return consumers and ranges where the existing range changed
      */
-    static ImpactedConsumersResult resolveConsumerRemovedHashRanges(List<HashRangeAssignment> mappingBefore,
+    static ImpactedConsumersResult resolveConsumerUpdatedHashRanges(List<HashRangeAssignment> mappingBefore,
                                                                     List<HashRangeAssignment> mappingAfter) {
         Map<Range, Pair<Consumer, Consumer>> impactedRanges = diffRanges(mappingBefore, mappingAfter);
-        Map<Consumer, SortedSet<Range>> removedRangesByConsumer = impactedRanges.entrySet().stream()
-                .collect(IdentityHashMap::new, (resultMap, entry) -> {
-                    Range range = entry.getKey();
-                    // filter out only where the range was removed
-                    Consumer consumerBefore = entry.getValue().getLeft();
-                    if (consumerBefore != null) {
-                        resultMap.computeIfAbsent(consumerBefore, k -> new TreeSet<>()).add(range);
-                    }
-                }, IdentityHashMap::putAll);
-        return mergedOverlappingRangesAndConvertToImpactedConsumersResult(removedRangesByConsumer);
+        Map<Consumer, SortedSet<Range>> addedRangesByConsumer = new IdentityHashMap<>();
+        Map<Consumer, SortedSet<Range>> removedRangesByConsumer = new IdentityHashMap<>();
+        impactedRanges.forEach((range, value) -> {
+            Consumer consumerAfter = value.getRight();
+
+            // last consumer was removed
+            if (consumerAfter != null) {
+                addedRangesByConsumer.computeIfAbsent(consumerAfter, k -> new TreeSet<>()).add(range);
+            }
+            // filter out only where the range was removed
+            Consumer consumerBefore = value.getLeft();
+            if (consumerBefore != null) {
+                removedRangesByConsumer.computeIfAbsent(consumerBefore, k -> new TreeSet<>()).add(range);
+            }
+        });
+        var removedMerged = mergedOverlappingRangesAndConvertToImpactedConsumersResult(removedRangesByConsumer);
+        var addedMerged = mergedOverlappingRangesAndConvertToImpactedConsumersResult(addedRangesByConsumer);
+        return ImpactedConsumersResult.of(removedMerged, addedMerged);
     }
 
-    static ImpactedConsumersResult mergedOverlappingRangesAndConvertToImpactedConsumersResult(
-            Map<Consumer, SortedSet<Range>> removedRangesByConsumer) {
-        Map<Consumer, RemovedHashRanges> mergedRangesByConsumer = new IdentityHashMap<>();
-        removedRangesByConsumer.forEach((consumer, ranges) -> {
-            mergedRangesByConsumer.put(consumer, RemovedHashRanges.of(mergeOverlappingRanges(ranges)));
+    static Map<Consumer, UpdatedHashRanges> mergedOverlappingRangesAndConvertToImpactedConsumersResult(
+            Map<Consumer, SortedSet<Range>> updatedRangesByConsumer) {
+        Map<Consumer, UpdatedHashRanges> mergedRangesByConsumer = new IdentityHashMap<>();
+        updatedRangesByConsumer.forEach((consumer, ranges) -> {
+            mergedRangesByConsumer.put(consumer, UpdatedHashRanges.of(mergeOverlappingRanges(ranges)));
         });
-        return ImpactedConsumersResult.of(mergedRangesByConsumer);
+        return mergedRangesByConsumer;
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java
@@ -397,15 +397,17 @@ public class DrainingHashesTracker {
             lock.writeLock().lock();
             try {
                 drainingHashes.remove(stickyKeyHash, entry);
-                // update the consumer specific stats
-                ConsumerDrainingHashesStats drainingHashesStats =
-                        consumerDrainingHashesStatsMap.get(new ConsumerIdentityWrapper(consumer));
-                if (drainingHashesStats != null) {
-                    drainingHashesStats.clearHash(stickyKeyHash);
-                }
             } finally {
                 lock.writeLock().unlock();
             }
+
+            // update the consumer specific stats
+            ConsumerDrainingHashesStats drainingHashesStats =
+                    consumerDrainingHashesStatsMap.get(new ConsumerIdentityWrapper(consumer));
+            if (drainingHashesStats != null) {
+                drainingHashesStats.clearHash(stickyKeyHash);
+            }
+
             return false;
         }
         // increment the blocked count which is used to determine if the hash is blocking

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/DrainingHashesTracker.java
@@ -397,6 +397,12 @@ public class DrainingHashesTracker {
             lock.writeLock().lock();
             try {
                 drainingHashes.remove(stickyKeyHash, entry);
+                // update the consumer specific stats
+                ConsumerDrainingHashesStats drainingHashesStats =
+                        consumerDrainingHashesStatsMap.get(new ConsumerIdentityWrapper(consumer));
+                if (drainingHashesStats != null) {
+                    drainingHashesStats.clearHash(stickyKeyHash);
+                }
             } finally {
                 lock.writeLock().unlock();
             }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ImpactedConsumersResult.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/ImpactedConsumersResult.java
@@ -30,22 +30,27 @@ import lombok.ToString;
 @EqualsAndHashCode
 @ToString
 public class ImpactedConsumersResult {
-    public interface RemovedHashRangesProcessor {
-        void process(Consumer consumer, RemovedHashRanges removedHashRanges);
+    public interface UpdatedHashRangesProcessor {
+        void process(Consumer consumer, UpdatedHashRanges updatedHashRanges, OperationType operationType);
     }
 
-    private final Map<Consumer, RemovedHashRanges> removedHashRanges;
+    private final Map<Consumer, UpdatedHashRanges> removedHashRanges;
+    private final Map<Consumer, UpdatedHashRanges> addedHashRanges;
 
-    private ImpactedConsumersResult(Map<Consumer, RemovedHashRanges> removedHashRanges) {
+    private ImpactedConsumersResult(Map<Consumer, UpdatedHashRanges> removedHashRanges,
+                                    Map<Consumer, UpdatedHashRanges> addedHashRanges) {
         this.removedHashRanges = removedHashRanges;
+        this.addedHashRanges = addedHashRanges;
     }
 
-    public static ImpactedConsumersResult of(Map<Consumer, RemovedHashRanges> removedHashRanges) {
-        return new ImpactedConsumersResult(removedHashRanges);
+    public static ImpactedConsumersResult of(Map<Consumer, UpdatedHashRanges> removedHashRanges,
+                                             Map<Consumer, UpdatedHashRanges> addedHashRanges) {
+        return new ImpactedConsumersResult(removedHashRanges, addedHashRanges);
     }
 
-    public void processRemovedHashRanges(RemovedHashRangesProcessor processor) {
-        removedHashRanges.forEach((c, r) -> processor.process(c, r));
+    public void processUpdatedHashRanges(UpdatedHashRangesProcessor processor) {
+        removedHashRanges.forEach((c, r) -> processor.process(c, r, OperationType.REMOVE));
+        addedHashRanges.forEach((c, r) -> processor.process(c, r, OperationType.ADD));
     }
 
     public boolean isEmpty() {
@@ -53,7 +58,16 @@ public class ImpactedConsumersResult {
     }
 
     @VisibleForTesting
-    Map<Consumer, RemovedHashRanges> getRemovedHashRanges() {
+    Map<Consumer, UpdatedHashRanges> getRemovedHashRanges() {
         return removedHashRanges;
+    }
+
+    @VisibleForTesting
+    Map<Consumer, UpdatedHashRanges> getAddedHashRanges() {
+        return addedHashRanges;
+    }
+
+    public enum OperationType {
+        ADD, REMOVE
     }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/UpdatedHashRanges.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/UpdatedHashRanges.java
@@ -29,10 +29,10 @@ import org.apache.pulsar.client.api.Range;
  */
 @EqualsAndHashCode
 @ToString
-public class RemovedHashRanges {
+public class UpdatedHashRanges {
     private final Range[] sortedRanges;
 
-    private RemovedHashRanges(List<Range> ranges) {
+    private UpdatedHashRanges(List<Range> ranges) {
         // Converts the set of ranges to an array to avoid iterator allocation
         // when the ranges are iterator multiple times in the pending acknowledgments loop.
         this.sortedRanges = ranges.toArray(new Range[0]);
@@ -52,8 +52,8 @@ public class RemovedHashRanges {
         }
     }
 
-    public static RemovedHashRanges of(List<Range> ranges) {
-        return new RemovedHashRanges(ranges);
+    public static UpdatedHashRanges of(List<Range> ranges) {
+        return new UpdatedHashRanges(ranges);
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentStickyKeyDispatcherMultipleConsumers.java
@@ -170,16 +170,25 @@ public class PersistentStickyKeyDispatcherMultipleConsumers extends PersistentDi
 
     private synchronized void registerDrainingHashes(Consumer skipConsumer,
                                                      ImpactedConsumersResult impactedConsumers) {
-        impactedConsumers.processRemovedHashRanges((c, removedHashRanges) -> {
+        impactedConsumers.processUpdatedHashRanges((c, updatedHashRanges, opType) -> {
             if (c != skipConsumer) {
                 c.getPendingAcks().forEach((ledgerId, entryId, batchSize, stickyKeyHash) -> {
                     if (stickyKeyHash == STICKY_KEY_HASH_NOT_SET) {
                         log.warn("[{}] Sticky key hash was missing for {}:{}", getName(), ledgerId, entryId);
                         return;
                     }
-                    if (removedHashRanges.containsStickyKey(stickyKeyHash)) {
-                        // add the pending ack to the draining hashes tracker if the hash is in the range
-                        drainingHashesTracker.addEntry(c, stickyKeyHash);
+                    if (updatedHashRanges.containsStickyKey(stickyKeyHash)) {
+                        switch (opType) {
+                            //reduce ref count in case the stickyKeyHash was re-assigned to the original consumer
+                            case ADD -> {
+                                var entry = drainingHashesTracker.getEntry(stickyKeyHash);
+                                if (entry != null && entry.getConsumer() == c) {
+                                    drainingHashesTracker.reduceRefCount(c, stickyKeyHash, false);
+                                }
+                            }
+                            // add the pending ack to the draining hashes tracker if the hash is in the range
+                            case REMOVE -> drainingHashesTracker.addEntry(c, stickyKeyHash);
+                        }
                     }
                 });
             }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumerHashAssignmentsSnapshotTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ConsumerHashAssignmentsSnapshotTest.java
@@ -129,14 +129,16 @@ public class ConsumerHashAssignmentsSnapshotTest {
         List<HashRangeAssignment> mappingBefore = new ArrayList<>();
         List<HashRangeAssignment> mappingAfter = new ArrayList<>();
 
+        Range notModifiedRange = Range.of(1, 5);
         Consumer consumer1 = createMockConsumer("consumer1");
-        mappingBefore.add(new HashRangeAssignment(Range.of(1, 5), consumer1));
-        mappingAfter.add(new HashRangeAssignment(Range.of(1, 5), consumer1));
+        mappingBefore.add(new HashRangeAssignment(notModifiedRange, consumer1));
+        mappingAfter.add(new HashRangeAssignment(notModifiedRange, consumer1));
 
         ImpactedConsumersResult impactedConsumers =
-                ConsumerHashAssignmentsSnapshot.resolveConsumerRemovedHashRanges(mappingBefore, mappingAfter);
+                ConsumerHashAssignmentsSnapshot.resolveConsumerUpdatedHashRanges(mappingBefore, mappingAfter);
 
         assertThat(impactedConsumers.getRemovedHashRanges()).isEmpty();
+        assertThat(impactedConsumers.getAddedHashRanges()).isEmpty();
     }
 
     @Test
@@ -144,49 +146,59 @@ public class ConsumerHashAssignmentsSnapshotTest {
         List<HashRangeAssignment> mappingBefore = new ArrayList<>();
         List<HashRangeAssignment> mappingAfter = new ArrayList<>();
 
+        Range reAssignedRange = Range.of(1, 5);
         Consumer consumer1 = createMockConsumer("consumer1");
         Consumer consumer2 = createMockConsumer("consumer2");
-        mappingBefore.add(new HashRangeAssignment(Range.of(1, 5), consumer1));
-        mappingAfter.add(new HashRangeAssignment(Range.of(1, 5), consumer2));
+        mappingBefore.add(new HashRangeAssignment(reAssignedRange, consumer1));
+        mappingAfter.add(new HashRangeAssignment(reAssignedRange, consumer2));
 
         ImpactedConsumersResult impactedConsumers =
-                ConsumerHashAssignmentsSnapshot.resolveConsumerRemovedHashRanges(mappingBefore, mappingAfter);
+                ConsumerHashAssignmentsSnapshot.resolveConsumerUpdatedHashRanges(mappingBefore, mappingAfter);
 
         assertThat(impactedConsumers.getRemovedHashRanges()).containsExactlyInAnyOrderEntriesOf(
-                Map.of(consumer1, RemovedHashRanges.of(List.of(Range.of(1, 5)))));
+                Map.of(consumer1, UpdatedHashRanges.of(List.of(reAssignedRange))));
+        assertThat(impactedConsumers.getAddedHashRanges()).containsExactlyInAnyOrderEntriesOf(
+                Map.of(consumer2, UpdatedHashRanges.of(List.of(reAssignedRange)))
+        );
     }
 
     @Test
-    public void testResolveConsumerRemovedHashRanges_RangeAdded() {
+    public void testResolveConsumerUpdatedHashRanges_RangeAdded() {
         List<HashRangeAssignment> mappingBefore = new ArrayList<>();
         List<HashRangeAssignment> mappingAfter = new ArrayList<>();
 
+        Range addedRange = Range.of(1, 5);
         Consumer consumer1 = createMockConsumer("consumer1");
-        mappingAfter.add(new HashRangeAssignment(Range.of(1, 5), consumer1));
+        mappingAfter.add(new HashRangeAssignment(addedRange, consumer1));
 
         ImpactedConsumersResult impactedConsumers =
-                ConsumerHashAssignmentsSnapshot.resolveConsumerRemovedHashRanges(mappingBefore, mappingAfter);
+                ConsumerHashAssignmentsSnapshot.resolveConsumerUpdatedHashRanges(mappingBefore, mappingAfter);
 
         assertThat(impactedConsumers.getRemovedHashRanges()).isEmpty();
+        assertThat(impactedConsumers.getAddedHashRanges()).containsExactlyInAnyOrderEntriesOf(
+                Map.of(consumer1, UpdatedHashRanges.of(List.of(addedRange)))
+        );
     }
 
     @Test
-    public void testResolveConsumerRemovedHashRanges_RangeRemoved() {
+    public void testResolveConsumerRemovedHashRanges_RangeUpdated() {
         List<HashRangeAssignment> mappingBefore = new ArrayList<>();
         List<HashRangeAssignment> mappingAfter = new ArrayList<>();
 
+        Range removedRange = Range.of(1, 5);
         Consumer consumer1 = createMockConsumer("consumer1");
-        mappingBefore.add(new HashRangeAssignment(Range.of(1, 5), consumer1));
+        mappingBefore.add(new HashRangeAssignment(removedRange, consumer1));
 
         ImpactedConsumersResult impactedConsumers =
-                ConsumerHashAssignmentsSnapshot.resolveConsumerRemovedHashRanges(mappingBefore, mappingAfter);
+                ConsumerHashAssignmentsSnapshot.resolveConsumerUpdatedHashRanges(mappingBefore, mappingAfter);
 
         assertThat(impactedConsumers.getRemovedHashRanges()).containsExactlyInAnyOrderEntriesOf(
-                Map.of(consumer1, RemovedHashRanges.of(List.of(Range.of(1, 5)))));
+                Map.of(consumer1, UpdatedHashRanges.of(List.of(removedRange))));
+        assertThat(impactedConsumers.getAddedHashRanges()).isEmpty();
     }
 
     @Test
-    public void testResolveConsumerRemovedHashRanges_OverlappingRanges() {
+    public void testResolveConsumerUpdatedHashRanges_OverlappingRanges() {
         List<HashRangeAssignment> mappingBefore = new ArrayList<>();
         List<HashRangeAssignment> mappingAfter = new ArrayList<>();
 
@@ -196,9 +208,12 @@ public class ConsumerHashAssignmentsSnapshotTest {
         mappingAfter.add(new HashRangeAssignment(Range.of(3, 7), consumer2));
 
         ImpactedConsumersResult impactedConsumers =
-                ConsumerHashAssignmentsSnapshot.resolveConsumerRemovedHashRanges(mappingBefore, mappingAfter);
+                ConsumerHashAssignmentsSnapshot.resolveConsumerUpdatedHashRanges(mappingBefore, mappingAfter);
 
         assertThat(impactedConsumers.getRemovedHashRanges()).containsExactlyInAnyOrderEntriesOf(
-                Map.of(consumer1, RemovedHashRanges.of(List.of(Range.of(3, 5)))));
+                Map.of(consumer1, UpdatedHashRanges.of(List.of(Range.of(3, 5)))));
+        assertThat(impactedConsumers.getAddedHashRanges()).containsExactlyInAnyOrderEntriesOf(
+                Map.of(consumer2, UpdatedHashRanges.of(List.of(Range.of(3, 7))))
+        );
     }
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/api/KeySharedSubscriptionTest.java
@@ -30,6 +30,7 @@ import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -917,6 +918,136 @@ public class KeySharedSubscriptionTest extends ProducerConsumerBase {
         Assert.assertEquals(receives.size(), messages);
         producer.close();
         consumer.close();
+    }
+
+    /*
+        Verifies https://github.com/apache/pulsar/issues/23845 issue fixed
+
+        The scenario of verification
+
+        Preconditions:
+
+        1. Consumer "consumer" up and running
+        2. Producer "producer" connected to broker
+
+        Steps to reproduce:
+        1. "producer" send message with key "testMessageKey"
+        Example: "testMessage" hash is always 124
+
+        2. "consumer" receives BUT DO NOT acknowledge message with key "testMessageKey"
+        Example: "consumer" hash range: [0-256]. "testMessage" hash range: [0-256]
+
+        3. Add more consumers until hash range of message with key "testMessageKey" removed from "consumer" hash ranges
+        Example: "consumer" hash range: [0-123]. "consumer N" hash range: [124-136]. "testMessage" hash range: [124-136]
+
+        4. Stop the added consumers until message key "testMessageKey" hash range moved to "consumer" hash ranges
+        Example: "consumer" hash range: [0-128]. "testMessage" hash range: [0-128]
+
+        5. Add more consumers until hash range of message with key "testMessageKey" removed from "consumer" hash ranges
+        Example: "consumer" hash range: [0-96]. "consumer N" hash range: [121-154]. "testMessage" hash range: [121-154]
+
+        6. Stop "consumer"
+
+        Actual result for bug:
+        No message with key "testMessageKey" received by consumer who owns message's hash range
+
+        Expected result:
+        The message with key "testMessageKey" received by consumer who owns message's hash range
+        Example: "consumer N" with hash range [121-154] received the message
+
+     */
+    @Test
+    void testMessageDeliveredFromDrainingHashes() throws PulsarClientException {
+        String messageKey = "testMessageKey";
+        String topic = "testMessageDeliveredFromDrainingHashes" + UUID.randomUUID();
+
+        List<Consumer<Integer>> consumers = new ArrayList<>();
+
+        @Cleanup
+        Consumer<Integer> consumer = createConsumer(topic);
+        String initialOwnerName = consumer.getConsumerName();
+
+        @Cleanup
+        Producer<Integer> producer = createProducer(topic, false);
+        producer.newMessage().key(messageKey).value(1).send();
+
+        // receive but not acknowledge the message to leave it in pending acks
+        Message<Integer> received = consumer.receive();
+        assertThat(received.getKey()).isEqualTo(messageKey);
+
+        StickyKeyDispatcher dispatcher = getDispatcher(topic, SUBSCRIPTION_NAME);
+        StickyKeyConsumerSelector selector = dispatcher.getSelector();
+        int messageKeyHash = selector.makeStickyKeyHash(messageKey.getBytes(StandardCharsets.UTF_8));
+
+        try {
+            // add new consumers until hash range of the initial message owner moved
+            Pair<String, List<Consumer<Integer>>> addedConsumers = addConsumersUntilOwnerChanged(
+                    topic, initialOwnerName, messageKeyHash, selector
+            );
+            String currentOwnerName = addedConsumers.getKey();
+            consumers.addAll(addedConsumers.getValue());
+
+            // returning hash range to the initial owner
+            for (int i = consumers.size() - 1; i > -1 && !initialOwnerName.equals(currentOwnerName); i--) {
+                consumers.remove(i).close();
+                currentOwnerName = findOwnerName(selector, messageKeyHash);
+            }
+
+            // add new consumers until hash range of the initial message owner moved
+            Pair<String, List<Consumer<Integer>>> addedConsumersAfter = addConsumersUntilOwnerChanged(
+                    topic, initialOwnerName, messageKeyHash, selector
+            );
+
+            String currentOwnerNameAfter = addedConsumersAfter.getKey();
+            consumers.addAll(addedConsumersAfter.getValue());
+
+            // remove the initial owner
+            consumer.close();
+
+            // verify the message sent to new consumer which owns hash range
+            Optional<Consumer<Integer>> theNewOwnerMaybe = consumers
+                    .stream()
+                    .filter(c -> c.getConsumerName().equals(currentOwnerNameAfter))
+                    .findAny();
+
+            assertThat(theNewOwnerMaybe).isPresent();
+
+            Consumer<Integer> theNewOwner = theNewOwnerMaybe.get();
+
+            Message<Integer> message = theNewOwner.receive(5, TimeUnit.SECONDS);
+            assertThat(message).describedAs("Message with key " + messageKey
+                    + " expected to be delivered to consumer " + theNewOwner.getConsumerName()).isNotNull();
+            assertThat(message.getKey()).isEqualTo(messageKey);
+        } finally {
+            for (Consumer<Integer> c : consumers) {
+                c.close();
+            }
+        }
+    }
+
+    private Pair<String, List<Consumer<Integer>>> addConsumersUntilOwnerChanged(
+            String topic,
+            String initialOwnerName,
+            int messageKeyHash,
+            StickyKeyConsumerSelector selector
+    ) throws PulsarClientException {
+        String currentOwnerName;
+        List<Consumer<Integer>> consumers = new ArrayList<>();
+        do {
+            Consumer<Integer> addedC = createConsumer(topic);
+            consumers.add(addedC);
+            currentOwnerName = findOwnerName(selector, messageKeyHash);
+        } while (initialOwnerName.equals(currentOwnerName));
+        return Pair.of(currentOwnerName, consumers);
+    }
+
+    private String findOwnerName(StickyKeyConsumerSelector selector, int hash) {
+        return selector.getConsumerKeyHashRanges().entrySet().stream()
+                .filter(entry ->
+                        entry.getValue().stream().anyMatch(range -> range.contains(hash))
+                )
+                .findAny().orElseThrow(() -> new IllegalArgumentException("No owner for the hash " + hash))
+                .getKey().consumerName();
     }
 
     @Test(dataProvider = "currentImplementationType")


### PR DESCRIPTION
Fixes https://github.com/apache/pulsar/issues/23845

<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

### Motivation
There is a not covered scenario for draining hashes and key shared subscriptions at `PersistentStickyKeyDispatcherMultipleConsumers`. The detailed scenario described at https://github.com/apache/pulsar/issues/23845#issuecomment-3269364004
As a result draining hashes could contain entries with consumer which was stopped. This leads consuming to get stuck.
<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->

### Modifications

Decrease draining hash entry `refCount` in case its hash range returned to the initial owner which holds the entry in pending acks.

<!-- Describe the modifications you've done. -->

### Verifying this change

- [x] Make sure that the change passes the CI checks.

This change added tests and can be verified as follows:


- *Added integration test `org.apache.pulsar.client.api.KeySharedSubscriptionTest#testMessageDeliveredFromDrainingHashes` to verify the scenario*
- Existing unit tests were modified to check changes applied in PR: `org.apache.pulsar.broker.service.ConsistentHashingStickyKeyConsumerSelectorTest#testShouldNotSwapExistingConsumers`, `org.apache.pulsar.broker.service.ConsumerHashAssignmentsSnapshotTest#testResolveConsumerRemovedHashRanges_NoChanges`, `org.apache.pulsar.broker.service.ConsumerHashAssignmentsSnapshotTest#testResolveConsumerUpdatedHashRanges_RangeAdded`, `org.apache.pulsar.broker.service.ConsumerHashAssignmentsSnapshotTest#testResolveConsumerRemovedHashRanges_RangeUpdated`, `org.apache.pulsar.broker.service.ConsumerHashAssignmentsSnapshotTest#testResolveConsumerUpdatedHashRanges_OverlappingRanges`


### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: https://github.com/nborisov/pulsar/pull/4 <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
